### PR TITLE
Print short description of each error at end of compile log

### DIFF
--- a/CompilePalX/Compiling/CompilingManager.cs
+++ b/CompilePalX/Compiling/CompilingManager.cs
@@ -104,7 +104,7 @@ namespace CompilePalX
                 {
                     i++;
 
-                    string errorText = string.Format("({0}) - ({1})", i, Error.GetSeverityText(error.Severity)) + Environment.NewLine;
+                    string errorText = string.Format("({0}) - {1} ({2})", i, error.ShortDescription, Error.GetSeverityText(error.Severity)) + Environment.NewLine;
 
                     CompilePalLogger.LogCompileError(errorText, error);
 

--- a/CompilePalX/Compiling/ErrorFinder.cs
+++ b/CompilePalX/Compiling/ErrorFinder.cs
@@ -20,6 +20,7 @@ namespace CompilePalX
         //interlopers list of errors
         private static string errorURL = "http://www.interlopers.net/includes/errorpage/errorChecker.txt";
 
+        private static Regex errorDescriptionPattern = new Regex("<h4>(.*?)</h4>");
 
         private static string errorStyle = Path.Combine("Compiling", "errorstyle.html");
         private static string errorCache = Path.Combine("Compiling", "errors.txt");
@@ -74,7 +75,8 @@ namespace CompilePalX
                 error.RegexTrigger = new Regex(data[1]);
                 i++;
 
-
+                var shortDesc = errorDescriptionPattern.Match(lines[i]);
+                error.ShortDescription = shortDesc.Success ? shortDesc.Groups[1].Value : "unknown error";
 
                 error.Message = style.Replace("%content%", lines[i]);
 
@@ -115,6 +117,7 @@ namespace CompilePalX
     {
         public Regex RegexTrigger;
         public string Message;
+        public string ShortDescription;
         public int Severity;
 
         public int ID;


### PR DESCRIPTION
Prints short description for each error that happened. 

Example log output:
```
2 errors/warnings logged:
(1) - Can't load skybox file [sub:1] to build the default cubemap! (Caution)
(2) - fastvis = true (Info)
```

The way I use to parse the short description is a bit weird (HTML & Regex anyone), but seems to work for error messages I tried.