### PR TITLE
Added support for command line arguments

### DIFF
--- a/CompilePalX/GameConfiguration/LaunchWindow.xaml.cs
+++ b/CompilePalX/GameConfiguration/LaunchWindow.xaml.cs
@@ -46,7 +46,7 @@ namespace CompilePalX
             //try loading from registry
             if (rk != null)
             {
-                string BinFolder = (string)rk.GetValue("Directory");
+                string BinFolder = (string) rk.GetValue("Directory");
 
 
                 string gameData = Path.Combine(BinFolder, "GameConfig.txt");
@@ -70,10 +70,42 @@ namespace CompilePalX
 
                 GameGrid.ItemsSource = configs;
             }
-            else//oh noes
+            else //oh noes
             {
                 LaunchButton.IsEnabled = false;
                 WarningLabel.Content = "No Hammer configurations found. Cannot launch.";
+            }
+
+            //Handle command line args for game configs
+            string[] commandLineArgs = Environment.GetCommandLineArgs();
+            foreach (string arg in commandLineArgs)
+            {
+                try
+                {
+                    //If arg type is a game, continue
+                    if (arg.Substring(0, 5).ToLower() == "game:")
+                    {
+                        //Make everything lowercase, remove arg type, and remove spaces
+                        string argGameConfig = arg.ToLower().Remove(0, 5).Replace(" ", "");
+
+                        //Search all configs to see if arg is a match
+                        foreach (GameConfiguration config in configs)
+                        {
+                            //Remove spaces and make everything lowercase
+                            string configName = config.Name.ToLower().Replace(" ", "");
+
+                            //If arg matches, launch that configuration
+                            if (argGameConfig == configName)
+                            {
+                                Launch(config);
+                            }
+                        }
+                    }
+                }
+                catch (ArgumentOutOfRangeException e)
+                {
+                    //Ignore error
+                }
             }
         }
 

--- a/CompilePalX/GameConfiguration/LaunchWindow.xaml.cs
+++ b/CompilePalX/GameConfiguration/LaunchWindow.xaml.cs
@@ -46,7 +46,7 @@ namespace CompilePalX
             //try loading from registry
             if (rk != null)
             {
-                string BinFolder = (string) rk.GetValue("Directory");
+                string BinFolder = (string)rk.GetValue("Directory");
 
 
                 string gameData = Path.Combine(BinFolder, "GameConfig.txt");

--- a/CompilePalX/GameConfiguration/LaunchWindow.xaml.cs
+++ b/CompilePalX/GameConfiguration/LaunchWindow.xaml.cs
@@ -70,7 +70,7 @@ namespace CompilePalX
 
                 GameGrid.ItemsSource = configs;
             }
-            else //oh noes
+            else//oh noes
             {
                 LaunchButton.IsEnabled = false;
                 WarningLabel.Content = "No Hammer configurations found. Cannot launch.";

--- a/CompilePalX/MainWindow.xaml.cs
+++ b/CompilePalX/MainWindow.xaml.cs
@@ -74,8 +74,51 @@ namespace CompilePalX
 
             CompilingManager.OnStart += CompilingManager_OnStart;
             CompilingManager.OnFinish += CompilingManager_OnFinish;
+
+            HandleMapPathArgs();
         }
 
+        private void HandleMapPathArgs(bool ignoreWipeArg = false)
+        {
+            //Handle command line args for map paths
+            string[] commandLineArgs = Environment.GetCommandLineArgs();
+            foreach (string arg in commandLineArgs)
+            {
+                try
+                {
+                    //If arg type is a path, continue
+                    if (arg.Substring(0, 5).ToLower() == "path:")
+                    {
+                        //Remove arg type
+                        string argPath = arg.Remove(0, 5);
+
+                        if (File.Exists(argPath))
+                        {
+                            if (argPath.EndsWith(".vmf") || argPath.EndsWith(".vmm") || argPath.EndsWith(".vmx"))
+                                CompilingManager.MapFiles.Add(argPath);
+                        }
+                    }
+                    else
+                    {
+                        if (!ignoreWipeArg)
+                        {
+                            //Wipes the map list
+                            if (arg.Substring(0, 5).ToLower() == "wipe!")
+                            {
+                                CompilingManager.MapFiles.Clear();
+                                //Recursive so if the wipe arg comes after a path, it will readd it
+                                HandleMapPathArgs(true);
+                                break;
+                            }
+                        }
+                    }
+                }
+                catch (ArgumentOutOfRangeException e)
+                {
+                    //Ignore error
+                }
+            }
+        }
 
         void CompilePalLogger_OnError(string errorText, Error e)
         {


### PR DESCRIPTION
Command line args would allow a few compile pal parameters to be setup by external programs 

**Game config args:**
-Purpose: Selects a game config and skips the launch window.
-Format: game:yourgameconfig
-Must be surrounded by quotation marks if arg contains spaces
-Not case sensitive

Example: game:TeamFortress2
Example: game:"Team Fortress 2"

**Path args:**
-Purpose: Adds a map to the compile manager
-Format: path:yourpath
-Must be surrounded by quotation marks if arg contains spaces
-Not case sensitive
-Must end in .vmf, .vmm, or .vmx (vmx compiles properly, might as well allow it to have more options)
-Checks if file exists just to be safe

Example: path:"C:\Program Files (x86)\Steam\steamapps\common\sourcesdk_content\tf2\mapsrc\test.vmf"

**Wipe arg:**
-Purpose: Wipes all maps in the compile manager
-Format: wipe!
-Not case sensitive
-Wipes any existing maps in the compile manager
-Will not wipe maps added through command line args, so you don't have to worry about it wiping the maps you are adding

Example: wipe!