### PR TITLE
Re-wrote GameConfigurationParser.cs

### DIFF
--- a/CompilePalX/GameConfiguration/GameConfigurationParser.cs
+++ b/CompilePalX/GameConfiguration/GameConfigurationParser.cs
@@ -1,120 +1,173 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Windows.Forms;
-using CompilePalX.Compiling;
+using System.Text.RegularExpressions;
 
-namespace CompilePalX
-{
-    class GameConfigurationParser
-    {
-        public static List<GameConfiguration> Parse(string filename)
-        {
-            CompilePalLogger.LogLine("Parsing game configuration file {0}",filename);
+public static class sutil {
+    public static string get_unquoted_material(string ii) {
+        string[] sgts = ii.Split('\"');
+        string u = "";
+        int i = 0;
+        foreach (string s in sgts) {
+            if (i++ % 2 != 0) continue;
+            u += s;
+        }
+        return u;
+    }
 
-            var lines = File.ReadAllLines(filename);
-            //not as lazy parsing! woo!
+    public static string GetFullPath(string line, string gameInfoDir) {
+        if (!line.StartsWith("..") || !line.StartsWith(""))
+            return line;
 
-            var gameInfos = new List<GameConfiguration>();
-            for (int i = 4; i < lines.Length; i++)
-            {
-                string line = lines[i];
+        string fullPath = Path.GetFullPath(Path.Combine(gameInfoDir, line));
+        return fullPath;
+    }
+}
 
-                if (line == "	}" || line == "        }")
-                    break;
+namespace KV {
+    public static class KV {
+        public static Regex rx = new Regex("\"(.*?)\"|([^\\s]+)", RegexOptions.Compiled);
+    }
 
-                var game = new GameConfiguration { Name = GetKey(line) };
+    public class DataBlock {
+        public string name = "";
+        public List<DataBlock> subBlocks = new List<DataBlock>();
+        public Dictionary<string, string> values = new Dictionary<string, string>();
 
-                game.BinFolder = Path.GetDirectoryName(filename);
+        public DataBlock() { }
 
-                CompilePalLogger.LogLine("Loading new game configuration:");
-                CompilePalLogger.LogLine(GetKey(line));
+        public DataBlock(ref System.IO.StreamReader stream, string name = "") {
+            this.name = name.Trim();
 
-                i++;
-                for (; i < lines.Length; i++)
-                {
-                    line = lines[i];
-                    if (IsValid(line))
-                    {
-                        switch (GetKey(line))
-                        {
-                            case "GameDir":
-                                game.GameFolder = GetFullPath(GetValue(line), game.BinFolder);
-                                CompilePalLogger.LogLine(GetKey(line) + ":" + GetValue(line));
-                                break;
-                            case "GameExe":
-                                game.GameEXE = GetFullPath(GetValue(line), game.BinFolder);
-                                CompilePalLogger.LogLine(GetKey(line) + ":" + GetValue(line));
-                                break;
-                            case "MapDir":
-                                game.SDKMapFolder = GetFullPath(GetValue(line), game.BinFolder);
-                                CompilePalLogger.LogLine(GetKey(line) + ":" + GetValue(line));
-                                break;
-                            case "BSP":
-                                game.VBSP = GetFullPath(GetValue(line), game.BinFolder);
+            string line = "";
+            string prev = "";
 
-								// incase vbsp is stored as relative path
-	                            if (String.IsNullOrEmpty(Path.GetDirectoryName(game.VBSP)))
-		                            game.VBSP = Path.Combine(game.BinFolder, game.VBSP);
+            while((line = stream.ReadLine()) != null) {
+                line = line.Split("//".ToCharArray())[0]; // ditch comments
 
-                                CompilePalLogger.LogLine(GetKey(line) + ":" + GetValue(line));
-                                break;
-                            case "Vis":
-                                game.VVIS = GetFullPath(GetValue(line), game.BinFolder);
-
-								if (String.IsNullOrEmpty(Path.GetDirectoryName(game.VVIS)))
-									game.VVIS = Path.Combine(game.BinFolder, game.VVIS);
-
-								CompilePalLogger.LogLine(GetKey(line) + ":" + GetValue(line));
-                                break;
-                            case "Light":
-                                game.VRAD = GetFullPath(GetValue(line), game.BinFolder);
-
-                                if (String.IsNullOrEmpty(Path.GetDirectoryName(game.VRAD)))
-									game.VRAD = Path.Combine(game.BinFolder, game.VRAD);
-
-								CompilePalLogger.LogLine(GetKey(line) + ":" + GetValue(line));
-                                break;
-                            case "BSPDir":
-                                game.MapFolder = GetFullPath(GetValue(line), game.BinFolder);
-                                CompilePalLogger.LogLine(GetKey(line) + ":" + GetValue(line));
-                                break;
-                        }
-                    }
-
-                    if (line == "		}" || line == "                }")
-                    {
-                        gameInfos.Add(game);
-                        break;
-                    }
+                if (sutil.get_unquoted_material(line).Contains("{")) {
+                    string pname = prev;
+                    prev.Replace("\"", "");
+                    this.subBlocks.Add(new DataBlock(ref stream, pname));
                 }
+                if (sutil.get_unquoted_material(line).Contains("}")) {
+                    return;
+                }
+
+                MatchCollection _matches = KV.rx.Matches(line);
+                List<string> strings = new List<string>();
+
+                for(int i = 0; i < _matches.Count; i++) {
+                    strings.Add(_matches[i].Value.ToString().Replace("\"", ""));
+                }
+
+                if(strings.Count == 2) {
+                    string keyname = strings[0];
+                    int i = -1;
+                    while (this.values.ContainsKey((++i > 0 ? keyname + i : keyname))) ;
+                    this.values[i > 0 ? keyname + i : keyname] = strings[1];
+                }
+
+                prev = line;
+            }
+        }
+
+        public void Serialize(ref System.IO.StreamWriter stream, int depth = 0) {
+            string indenta = "";
+            for (int i = 0; i < depth; i++)
+                indenta += "\t";
+            string indentb = indenta + "\t";
+
+            if (depth >= 0)
+                stream.Write(indenta + this.name + "\n" + indenta + "{\n");
+
+            foreach (string key in this.values.Keys)
+                stream.Write(indentb + "\"" + key + "\" \"" + this.values[key] + "\"\n");
+
+            for (int i = 0; i < this.subBlocks.Count; i++)
+                this.subBlocks[i].Serialize(ref stream, depth + 1);
+
+            if (depth >= 0)
+                stream.Write(indenta + "}\n");
+        }
+
+        public DataBlock GetFirstByName(string _name) {
+            for (int i = 0; i < this.subBlocks.Count; i++)
+                if (_name == this.subBlocks[i].name)
+                    return this.subBlocks[i];
+
+            return null;
+        }
+
+        public List<DataBlock> GetAllByName(string _name) {
+            List<DataBlock> c = new List<DataBlock>();
+            for (int i = 0; i < this.subBlocks.Count; i++)
+                if (_name == this.subBlocks[i].name)
+                    c.Add(this.subBlocks[i]);
+
+            return c;
+        }
+
+        public string tryGetStringValue(string key, string defaultValue = "") {
+            if (!this.values.ContainsKey(key)) return defaultValue;
+            return this.values[key];
+        }
+
+        public List<string> getList(string key) {
+            List<string> list = new List<string>();
+            int vc = -1;
+            while (this.values.ContainsKey(key + (++vc > 0 ? vc.ToString() : ""))) list.Add(this.values[key + (vc > 0 ? vc.ToString() : "")]);
+            return list;
+        }
+    }
+
+    public class FileData {
+        public DataBlock headnode;
+
+        public FileData(string filename) {
+            System.IO.StreamReader s = new System.IO.StreamReader(filename);
+            this.headnode = new DataBlock(ref s, "");
+            s.Close();
+        }
+    }
+}
+
+namespace CompilePalX {
+    class GameConfigurationParser {
+        public static List<GameConfiguration> Parse(string filename) {
+            var lines = File.ReadAllLines(filename);
+            var gameInfos = new List<GameConfiguration>();
+
+            KV.FileData data = new KV.FileData(filename);
+
+            foreach (KV.DataBlock gamedb in data.headnode.GetFirstByName("\"Configs\"").GetFirstByName("\"Games\"").subBlocks) {
+                string binfolder = Path.GetDirectoryName(filename);
+                KV.DataBlock hdb = gamedb.GetFirstByName("\"Hammer\"");
+
+                GameConfiguration game = new GameConfiguration {
+                    Name =          gamedb.name.Replace("\"", ""),
+                    BinFolder =     binfolder,
+                    GameFolder =    GetFullPath(gamedb.tryGetStringValue("GameDir"),    binfolder),
+                    GameEXE =       GetFullPath(hdb.tryGetStringValue("GameExe"),       binfolder),
+                    SDKMapFolder =  GetFullPath(hdb.tryGetStringValue("MapDir"),        binfolder),
+                    VBSP =          GetFullPath(hdb.tryGetStringValue("BSP"),           binfolder),
+                    VVIS =          GetFullPath(hdb.tryGetStringValue("Vis"),           binfolder),
+                    VRAD =          GetFullPath(hdb.tryGetStringValue("Light"),         binfolder),
+                    MapFolder =     GetFullPath(hdb.tryGetStringValue("BSPDir"),        binfolder)
+                };
+
+                gameInfos.Add(game);
             }
 
             return gameInfos;
         }
 
-        static private bool IsValid(string line)
-        {
-            return line.Contains("\"");
+        static private string GetFullPath(string line, string gameInfoDir) {
+            if (!line.StartsWith("..") || !line.StartsWith(""))
+                return line;
+
+            string fullPath = Path.GetFullPath(Path.Combine(gameInfoDir, line));
+            return fullPath;
         }
-
-        static private string GetValue(string line)
-        {
-            return line.Split('"')[3];
-        }
-
-        static private string GetKey(string line)
-        {
-            return line.Split('"')[1];
-        }
-
-	    static private string GetFullPath(string line, string gameInfoDir)
-	    {
-		    if (!line.StartsWith("..") || !line.StartsWith(""))
-			    return line;
-
-		    string fullPath = Path.GetFullPath(Path.Combine(gameInfoDir, line));
-		    return fullPath;
-	    }
     }
 }


### PR DESCRIPTION
Compilepal crashes when the structure of GameConfig.txt is changed.
For example after installing my tool AutoRadar for CS:GO, the structure is modified but is still read fine by hammer, but causes fatal error in compilepal.

This version will do a full KV parse therefore should account for every setup.