### PR TITLE
Stop compiling after a VBSP leak in Portal 2

### DIFF
--- a/CompilePalX/Compiling/CompilingManager.cs
+++ b/CompilePalX/Compiling/CompilingManager.cs
@@ -115,7 +115,19 @@ namespace CompilePalX
                         compileProcess.Run(GameConfigurationManager.BuildContext(mapFile));
 
                         if (compileProcess is CompileExecutable executable)
-	                        compileErrors.AddRange(executable.CompileErrors);
+                        {
+                            compileErrors.AddRange(executable.CompileErrors);
+
+                            //Portal 2 cannot work with leaks, stop compiling if we do get a leak.
+                            if (GameConfigurationManager.GameConfiguration.Name == "Portal 2")
+                            {
+                                if (executable.Name == "VBSP" && executable.CompileErrors.Count > 0)
+                                {
+                                    //we have a VBSP error, aka a leak -> stop compiling;
+                                    break;
+                                }
+                            }
+                        }
 
                         ProgressManager.Progress += (1d / ConfigurationManager.CompileProcesses.Count(c => c.Metadata.DoRun &&
                             c.PresetDictionary.ContainsKey(ConfigurationManager.CurrentPreset))) / MapFiles.Count;


### PR DESCRIPTION
As portal 2 cannot run maps with leaks in it, it'll halt if it encounters an error on VBSP, if compiling for Portal 2. This prevents excessive VVIS and VRAD runs, and makes it quicker to see that there's a serious issue for the developer.

(Developed as a request from the ThinkingWithPortals Portal 2 mapping Discord)