### PR TITLE
Fixed Particle File Packing

### DIFF
--- a/CompilePalX/CompilePalX.csproj
+++ b/CompilePalX/CompilePalX.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Costura.Fody.4.0.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.4.0.0\build\Costura.Fody.props')" />
+  <Import Project="..\packages\Costura.Fody.5.0.0-alpha0281\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.5.0.0-alpha0281\build\Costura.Fody.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -46,8 +46,8 @@
     <Reference Include="ControlzEx, Version=3.0.2.4, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ControlzEx.3.0.2.4\lib\net45\ControlzEx.dll</HintPath>
     </Reference>
-    <Reference Include="Costura, Version=4.0.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Costura.Fody.4.0.0\lib\net40\Costura.dll</HintPath>
+    <Reference Include="Costura, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Costura.Fody.5.0.0-alpha0281\lib\netstandard1.0\Costura.dll</HintPath>
     </Reference>
     <Reference Include="MahApps.Metro, Version=1.4.3.0, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.1.4.3\lib\net45\MahApps.Metro.dll</HintPath>
@@ -65,11 +65,18 @@
       <HintPath>..\packages\Microsoft.WindowsAPICodePack-Shell.1.1.0.0\lib\Microsoft.WindowsAPICodePack.ShellExtensions.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.1.4.3\lib\net45\System.Windows.Interactivity.dll</HintPath>
     </Reference>
@@ -453,16 +460,15 @@
     <Delete Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).xml')" />
     <Delete Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).config')" />
   </Target>
-  <Import Project="..\packages\Fody.5.0.6\build\Fody.targets" Condition="Exists('..\packages\Fody.5.0.6\build\Fody.targets')" />
+  <Target Name="CleanOutputDirectory" AfterTargets="Clean">
+    <RemoveDir Directories="$(OUTDIR)" />
+  </Target>
+  <Import Project="..\packages\Fody.6.2.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.2.0\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.5.0.6\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.5.0.6\build\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\Costura.Fody.4.0.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.4.0.0\build\Costura.Fody.props'))" />
-  </Target>
-  <Target Name="CleanOutputDirectory"
-          AfterTargets="Clean">
-    <RemoveDir Directories="$(OUTDIR)"/>
+    <Error Condition="!Exists('..\packages\Fody.6.2.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.2.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Costura.Fody.5.0.0-alpha0281\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.5.0.0-alpha0281\build\Costura.Fody.props'))" />
   </Target>
 </Project>

--- a/CompilePalX/Compilers/BSPPack/AssetUtils.cs
+++ b/CompilePalX/Compilers/BSPPack/AssetUtils.cs
@@ -587,6 +587,7 @@ namespace CompilePalX.Compilers.BSPPack
             string name = bsp.file.Name.Replace(".bsp", "");
             string searchPattern = name + "*.txt";
             List<KeyValuePair<string, string>> langfiles = new List<KeyValuePair<string, string>>();
+            bool particleManifestPacked = false;
 
             foreach (string source in sourceDirectories)
             {
@@ -596,19 +597,35 @@ namespace CompilePalX.Compilers.BSPPack
                 if (dir.Exists)
                     foreach (FileInfo f in dir.GetFiles(searchPattern))
                     {
-                        // particle files if particle manifest is not being generated
-                        if (!genparticlemanifest)
+                        // pack the first particle manifest file seen if not generating one? if we generate one does it get added already?
+                        if (!genparticlemanifest && !particleManifestPacked)
+                        {
                             if (f.Name.StartsWith(name + "_particles") || f.Name.StartsWith(name + "_manifest"))
-                                bsp.particleManifest =
-                                    new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name);
+                            {
+                                particleManifestPacked = true;
+                                bsp.particleManifest = new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name);
+                                continue;
+                            }
+                        }
 
                         // soundscript
                         if (f.Name.StartsWith(name + "_level_sounds"))
-                            bsp.soundscript =
-                                new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name);
+                        {
+                            bsp.soundscript = new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name);
+                        }
                         // presumably language files
                         else
+                        {
+                            // don't pack particle manifests if we generated one
+                            if (genparticlemanifest)
+                            {
+                                if (f.Name.StartsWith(name + "_particles") || f.Name.StartsWith(name + "_manifest"))
+                                {
+                                    continue;
+                                }
+                            }
                             langfiles.Add(new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name));
+                        }
                     }
             }
             bsp.languages = langfiles;

--- a/CompilePalX/Compilers/Utility/ParticleUtils.cs
+++ b/CompilePalX/Compilers/Utility/ParticleUtils.cs
@@ -451,14 +451,24 @@ namespace CompilePalX.Compilers.UtilityProcess
                 foreach (PCF particle in particles)
                 {
                     string internalParticlePath = particle.FilePath.Replace(baseDirectory, "");
+                    // remove custom paths
+                    if (internalParticlePath.StartsWith("custom\\"))
+                    {
+                        var chopIndex = internalParticlePath.IndexOf("particles");
+                        if(chopIndex != -1)
+                        {
+                            internalParticlePath = internalParticlePath.Substring(chopIndex, internalParticlePath.Length - chopIndex);
+                        }
+                    }
                     sw.WriteLine($"      \"file\"    \"!{internalParticlePath}\"");
                     CompilePalLogger.LogLine($"PCF added to manifest: {internalParticlePath}");
                 }
 
                 sw.WriteLine("}");
             }
-            
-            string internalDirectory = filepath.Replace(baseDirectory, "");
+
+
+            string internalDirectory = filepath.Substring(baseDirectory.Length);
 
             //Store internal/external dir so it can be packed
             particleManifest = new KeyValuePair<string, string>(internalDirectory, filepath);

--- a/CompilePalX/FodyWeavers.xsd
+++ b/CompilePalX/FodyWeavers.xsd
@@ -17,6 +17,16 @@
                   <xs:documentation>A list of assembly names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="ExcludeRuntimeAssemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of (.NET Core) runtime assembly names to exclude from the default action of "embed all Copy Local references", delimited with line breaks</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="IncludeRuntimeAssemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of (.NET Core) runtime assembly names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged32Assemblies" type="xs:string">
                 <xs:annotation>
                   <xs:documentation>A list of unmanaged 32 bit assembly names to include, delimited with line breaks.</xs:documentation>
@@ -41,6 +51,11 @@
             <xs:attribute name="IncludeDebugSymbols" type="xs:boolean">
               <xs:annotation>
                 <xs:documentation>Controls if .pdbs for reference assemblies are also embedded.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IncludeRuntimeReferences" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Controls if (.NET Core) runtime assemblies are also embedded.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="DisableCompression" type="xs:boolean">
@@ -71,6 +86,16 @@
             <xs:attribute name="IncludeAssemblies" type="xs:string">
               <xs:annotation>
                 <xs:documentation>A list of assembly names to include from the default action of "embed all Copy Local references", delimited with |.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ExcludeRuntimeAssemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of (.NET Core) runtime assembly names to exclude from the default action of "embed all Copy Local references", delimited with |</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IncludeRuntimeAssemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of (.NET Core) runtime assembly names to include from the default action of "embed all Copy Local references", delimited with |.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="Unmanaged32Assemblies" type="xs:string">

--- a/CompilePalX/packages.config
+++ b/CompilePalX/packages.config
@@ -2,11 +2,42 @@
 <packages>
   <package id="Analytics" version="3.0.0" targetFramework="net45" />
   <package id="ControlzEx" version="3.0.2.4" targetFramework="net45" />
-  <package id="Costura.Fody" version="4.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Fody" version="5.0.6" targetFramework="net45" developmentDependency="true" />
+  <package id="Costura.Fody" version="5.0.0-alpha0281" targetFramework="net45" developmentDependency="true" />
+  <package id="Fody" version="6.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="MahApps.Metro" version="1.4.3" targetFramework="net45" />
   <package id="MahApps.Metro.IconPacks" version="2.3.0" targetFramework="net45" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAPICodePack-Core" version="1.1.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAPICodePack-Shell" version="1.1.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net45" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixes issue #122

Fixed issue with not stripping "custom/blah/" from custom/blah/particles/p.pcf.

Fixed issue with packing particle manifest files that weren't generated with compilepal when we are generating one.

Fixed issue with generated particle manifest not having a valid internal directory by switching from replace to substring. Not sure why replace didn't work, but it wasn't removing the baseDirectory and substring is more correct as it removes from the beginning of the path instead of possibly from the middle.