### PR TITLE
Add -excludevpk option to packing

### DIFF
--- a/CompilePalX/Compilers/BSPPack/Pack.cs
+++ b/CompilePalX/Compilers/BSPPack/Pack.cs
@@ -40,6 +40,7 @@ namespace CompilePalX.Compilers.BSPPack
         private static bool includeDir;
         private static bool exclude;
         private static bool excludeDir;
+        private static bool excludevpk;
         private static bool packvpk;
         private static bool includefilelist;
         private static bool usefilelist;
@@ -61,6 +62,7 @@ namespace CompilePalX.Compilers.BSPPack
             includeDir = GetParameterString().Contains("-includedir");
             exclude = Regex.IsMatch(GetParameterString(), @"-exclude\b"); // ensures it doesnt match -excludedir
             excludeDir = GetParameterString().Contains("-excludedir");
+            excludevpk = GetParameterString().Contains("-excludevpk");
             packvpk = GetParameterString().Contains("-vpk");
             includefilelist = GetParameterString().Contains("-includefilelist");
             usefilelist = GetParameterString().Contains("-usefilelist");
@@ -71,7 +73,7 @@ namespace CompilePalX.Compilers.BSPPack
             List<string> includeFiles = new List<string>();
             List<string> excludeFiles = new List<string>();
             List<string> excludeDirs = new List<string>();
-
+            List<string> excludedVpkFiles = new List<string>();
 
             try
             {
@@ -196,6 +198,24 @@ namespace CompilePalX.Compilers.BSPPack
                     }
                 }
 
+                // exclude files that are in the specified vpk.
+                if (excludevpk)
+                {
+                    foreach (string parameter in parameters)
+                    {
+                        if (parameter.Contains("excludevpk"))
+                        {
+                            var filePath = parameter.Replace("\"", "").Replace("excludevpk ", "").TrimEnd(' ');
+
+                            string[] vpkFileList = GetVPKFileList("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Counter-Strike Global Offensive\\csgo\\pak01_dir.vpk");
+                            
+                            foreach (string file in vpkFileList)
+                            {
+                                excludedVpkFiles.Add(file.ToLower());
+                            }
+                        }
+                    }
+                }
 
                 CompilePalLogger.LogLine("Finding sources of game content...");
                 sourceDirectories = GetSourceDirectories(gameFolder);
@@ -217,7 +237,7 @@ namespace CompilePalX.Compilers.BSPPack
                 AssetUtils.findBspPakDependencies(map, unpackDir);
 
                 CompilePalLogger.LogLine("Initializing pak file...");
-                PakFile pakfile = new PakFile(map, sourceDirectories, includeFiles, excludeFiles, excludeDirs, outputFile);
+                PakFile pakfile = new PakFile(map, sourceDirectories, includeFiles, excludeFiles, excludeDirs, excludedVpkFiles, outputFile);
 
                 if (includefilelist)
                 {
@@ -486,6 +506,39 @@ namespace CompilePalX.Compilers.BSPPack
 
 
             p.WaitForExit();
+        }
+
+        static string[] GetVPKFileList(string VPKPath)
+		{
+            string arguments = $"l \"{VPKPath}\"";
+
+            var p = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    WorkingDirectory = Path.GetDirectoryName(vpk),
+                    FileName = vpk,
+                    Arguments = arguments,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                }
+            };
+            
+            p.Start();
+
+            string output = p.StandardOutput.ReadToEnd();
+            string errOutput = p.StandardError.ReadToEnd();
+            if (verbose)
+            {
+                CompilePalLogger.Log(errOutput);
+            }
+
+            p.WaitForExit();
+
+            char[] delims = new[] { '\r', '\n' };
+            return output.Split(delims, StringSplitOptions.RemoveEmptyEntries);
         }
 
         static void p_OutputDataReceived(object sender, DataReceivedEventArgs e)

--- a/CompilePalX/Compilers/BSPPack/Pack.cs
+++ b/CompilePalX/Compilers/BSPPack/Pack.cs
@@ -205,9 +205,9 @@ namespace CompilePalX.Compilers.BSPPack
                     {
                         if (parameter.Contains("excludevpk"))
                         {
-                            var filePath = parameter.Replace("\"", "").Replace("excludevpk ", "").TrimEnd(' ');
+                            var vpkPath = parameter.Replace("\"", "").Replace("excludevpk ", "").TrimEnd(' ');
 
-                            string[] vpkFileList = GetVPKFileList("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Counter-Strike Global Offensive\\csgo\\pak01_dir.vpk");
+                            string[] vpkFileList = GetVPKFileList(vpkPath);
                             
                             foreach (string file in vpkFileList)
                             {

--- a/CompilePalX/Compilers/BSPPack/PakFile.cs
+++ b/CompilePalX/Compilers/BSPPack/PakFile.cs
@@ -31,7 +31,8 @@ namespace CompilePalX.Compilers.BSPPack
             // exclude files that are excluded
             if (externalPath != "" && File.Exists(externalPath)
                                    && !excludedFiles.Contains(externalPath.ToLower().Replace('/', '\\'))
-                                   && !excludedDirs.Any(externalPath.ToLower().Replace('/', '\\').StartsWith))
+                                   && !excludedDirs.Any(externalPath.ToLower().Replace('/', '\\').StartsWith)
+                                   && !excludedVpkFiles.Contains(paths.Key.ToLower().Replace('\\', '/')))
             {
                 Files.Add(paths);
                 return true;
@@ -47,6 +48,7 @@ namespace CompilePalX.Compilers.BSPPack
 
         private List<string> excludedFiles;
 	    private List<string> excludedDirs;
+        private List<string> excludedVpkFiles;
 
         private List<string> sourceDirs;
         private string fileName;
@@ -59,7 +61,7 @@ namespace CompilePalX.Compilers.BSPPack
         public int effectscriptcount { get; private set; }
         public int vscriptcount { get; private set; }
 
-        public PakFile(BSP bsp, List<string> sourceDirectories, List<string> includeFiles, List<string> excludedFiles, List<string> excludedDirs, string outputFile)
+        public PakFile(BSP bsp, List<string> sourceDirectories, List<string> includeFiles, List<string> excludedFiles, List<string> excludedDirs, List<string> excludedVpkFiles, string outputFile)
         {
             mdlcount = vmtcount = pcfcount = sndcount = vehiclescriptcount = effectscriptcount = 0;
             sourceDirs = sourceDirectories;
@@ -67,6 +69,7 @@ namespace CompilePalX.Compilers.BSPPack
 
 	        this.excludedFiles = excludedFiles;
 	        this.excludedDirs = excludedDirs;
+	        this.excludedVpkFiles = excludedVpkFiles;
 
             Files = new Dictionary<string, string>();
 

--- a/CompilePalX/Parameters/PACK/parameters.json
+++ b/CompilePalX/Parameters/PACK/parameters.json
@@ -66,6 +66,16 @@
     "CanBeUsedMoreThanOnce": true
   },
   {
+    "Name": "Exclude VPK file",
+    "Parameter": " -excludevpk",
+    "Description": "Exclude files from packing that are already in the specified VPK",
+    "Value": null,
+    "ValueIsFile": true,
+    "CanHaveValue": true,
+    "Warning": "",
+    "CanBeUsedMoreThanOnce": true
+  },
+  {
     "Name": "VPK",
     "Parameter": " -vpk",
     "Description": "Pack into a VPK instead of BSP.",


### PR DESCRIPTION
Basically it doesn't pack files that are in the specified vpk.
My use case for this is porting maps where there can be a little bit of overlap with the same materials. Saving filesize is nice.