### PR TITLE
Improved keyvalue parsing in vmtPathParser

### DIFF
--- a/CompilePalX/Compilers/BSPPack/AssetUtils.cs
+++ b/CompilePalX/Compilers/BSPPack/AssetUtils.cs
@@ -722,7 +722,6 @@ namespace CompilePalX.Compilers.BSPPack
             string name = bsp.file.Name.Replace(".bsp", "");
             string searchPattern = name + "*.txt";
             List<KeyValuePair<string, string>> langfiles = new List<KeyValuePair<string, string>>();
-            bool particleManifestPacked = false;
 
             foreach (string source in sourceDirectories)
             {
@@ -732,30 +731,20 @@ namespace CompilePalX.Compilers.BSPPack
                 if (dir.Exists)
                     foreach (FileInfo f in dir.GetFiles(searchPattern))
                     {
-                        // only pack 1 particle manifest
-                        if (!genparticlemanifest && !particleManifestPacked)
+                        // particle files if particle manifest is not being generated
+                        if (f.Name.StartsWith(name + "_particles") || f.Name.StartsWith(name + "_manifest"))
                         {
-                            if (f.Name.StartsWith(name + "_particles") || f.Name.StartsWith(name + "_manifest"))
-                            {
-                                particleManifestPacked = true;
+                            if(!genparticlemanifest)
                                 bsp.particleManifest = new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name);
-                            }
+                            continue;
                         }
-
                         // soundscript
                         if (f.Name.StartsWith(name + "_level_sounds"))
                             bsp.soundscript =
                                 new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name);
                         // presumably language files
                         else
-                        {
-                            // don't pack existing particle manifests if we are generating one
-                            if (genparticlemanifest && (f.Name.StartsWith(name + "_particles") || f.Name.StartsWith(name + "_manifest")))
-                            {
-                                continue;
-                            }
                             langfiles.Add(new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name));
-                        }
                     }
             }
             bsp.languages = langfiles;

--- a/CompilePalX/Compilers/BSPPack/AssetUtils.cs
+++ b/CompilePalX/Compilers/BSPPack/AssetUtils.cs
@@ -437,9 +437,20 @@ namespace CompilePalX.Compilers.BSPPack
         {
             if (needsSplit)
                 vmtline = vmtline.Split(new char[] { ' ' }, 2)[1]; // removes the parameter name
-            vmtline = vmtline.Split(new string[] { "//", "\\\\" }, StringSplitOptions.None)[0]; // removes endline parameter
+
+            if (vmtline[0] == '"')
+            {
+                vmtline = Regex.Match(vmtline, "\"([^\"]+)\"").Groups[1].Value;
+            }
+            else
+            {
+                vmtline = Regex.Match(vmtline, "[^ ]+").Groups[0].Value;
+            }
+
             vmtline = vmtline.Trim(new char[] { ' ', '/', '\\' }); // removes leading slashes
             vmtline = vmtline.Replace('\\', '/'); // normalize slashes
+            vmtline = Regex.Replace(vmtline, "/+", "/"); // remove duplicate slashes
+
             if (vmtline.StartsWith("materials/"))
                 vmtline = vmtline.Remove(0, "materials/".Length); // removes materials/ if its the beginning of the string for consistency
             if (vmtline.EndsWith(".vmt") || vmtline.EndsWith(".vtf")) // removes extentions if present for consistency

--- a/CompilePalX/Compilers/BSPPack/AssetUtils.cs
+++ b/CompilePalX/Compilers/BSPPack/AssetUtils.cs
@@ -722,6 +722,7 @@ namespace CompilePalX.Compilers.BSPPack
             string name = bsp.file.Name.Replace(".bsp", "");
             string searchPattern = name + "*.txt";
             List<KeyValuePair<string, string>> langfiles = new List<KeyValuePair<string, string>>();
+            bool particleManifestPacked = false;
 
             foreach (string source in sourceDirectories)
             {
@@ -731,11 +732,15 @@ namespace CompilePalX.Compilers.BSPPack
                 if (dir.Exists)
                     foreach (FileInfo f in dir.GetFiles(searchPattern))
                     {
-                        // particle files if particle manifest is not being generated
-                        if (!genparticlemanifest)
+                        // only pack 1 particle manifest
+                        if (!genparticlemanifest && !particleManifestPacked)
+                        {
                             if (f.Name.StartsWith(name + "_particles") || f.Name.StartsWith(name + "_manifest"))
-                                bsp.particleManifest =
-                                    new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name);
+                            {
+                                particleManifestPacked = true;
+                                bsp.particleManifest = new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name);
+                            }
+                        }
 
                         // soundscript
                         if (f.Name.StartsWith(name + "_level_sounds"))
@@ -743,7 +748,14 @@ namespace CompilePalX.Compilers.BSPPack
                                 new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name);
                         // presumably language files
                         else
+                        {
+                            // don't pack existing particle manifests if we are generating one
+                            if (genparticlemanifest && (f.Name.StartsWith(name + "_particles") || f.Name.StartsWith(name + "_manifest")))
+                            {
+                                continue;
+                            }
                             langfiles.Add(new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name));
+                        }
                     }
             }
             bsp.languages = langfiles;

--- a/CompilePalX/Compilers/Utility/ParticleUtils.cs
+++ b/CompilePalX/Compilers/Utility/ParticleUtils.cs
@@ -465,9 +465,12 @@ namespace CompilePalX.Compilers.UtilityProcess
 
                 sw.WriteLine("}");
             }
-            
-            string internalDirectory = filepath.Replace(baseDirectory, "");
 
+            string internalDirectory = filepath;
+            if(filepath.ToLower().StartsWith(baseDirectory.ToLower()))
+            {
+                internalDirectory = filepath.Substring(baseDirectory.Length);
+            }
             //Store internal/external dir so it can be packed
             particleManifest = new KeyValuePair<string, string>(internalDirectory, filepath);
         }


### PR DESCRIPTION
Made parsing better by using regex so values with // in the middle don't get mangled.

This is not the best solution though, this project needs to use a real vdf parser in every part of the code that touches vdf files, but I do not have time for that.