### PR TITLE
Improved keyvalue parsing in vmtPathParser

### DIFF
--- a/CompilePalX/Compilers/BSPPack/AssetUtils.cs
+++ b/CompilePalX/Compilers/BSPPack/AssetUtils.cs
@@ -232,6 +232,12 @@ namespace CompilePalX.Compilers.BSPPack
 
                 mdl.Close();
             }
+
+            for(int i=0;i<materials.Count;i++)
+            {
+                materials[i] = Regex.Replace(materials[i], "/+", "/"); // remove duplicate slashes
+            }
+
             return new Tuple<List<string>, List<string>>(materials, models);
         }
 

--- a/CompilePalX/Compilers/BSPPack/AssetUtils.cs
+++ b/CompilePalX/Compilers/BSPPack/AssetUtils.cs
@@ -470,6 +470,12 @@ namespace CompilePalX.Compilers.BSPPack
             }
             else
             {
+                // strip c style comments like this one
+                var commentIndex = vmtline.IndexOf("//");
+                if(commentIndex > -1)
+                {
+                    vmtline = vmtline.Substring(0, commentIndex);
+                }
                 vmtline = Regex.Match(vmtline, "[^ \t]+").Groups[0].Value;
             }
 

--- a/CompilePalX/Compilers/BSPPack/BSP.cs
+++ b/CompilePalX/Compilers/BSPPack/BSP.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -17,6 +18,8 @@ namespace CompilePalX.Compilers.BSPPack
         private KeyValuePair<int, int>[] offsets; // offset/length
 
         public List<Dictionary<string, string>> entityList { get; private set; }
+
+        public List<List<Tuple<string, string>>> entityListArrayForm { get; private set; }
 
         public List<int>[] modelSkinList { get; private set; }
 
@@ -113,6 +116,7 @@ namespace CompilePalX.Compilers.BSPPack
         public void buildEntityList()
         {
             entityList = new List<Dictionary<string, string>>();
+            entityListArrayForm = new List<List<Tuple<string, string>>>();
 
             bsp.Seek(offsets[0].Key, SeekOrigin.Begin);
             byte[] ent = reader.ReadBytes(offsets[0].Value);
@@ -144,6 +148,7 @@ namespace CompilePalX.Compilers.BSPPack
 
 					string rawent = Encoding.ASCII.GetString(ents.ToArray());
                     Dictionary<string, string> entity = new Dictionary<string, string>();
+                    var entityArrayFormat = new List<Tuple<string, string>>();
 					// split on \n, ignore \n inside of quotes
                     foreach (string s in Regex.Split(rawent, "(?=(?:(?:[^\"]*\"){2})*[^\"]*$)\\n"))
                     {
@@ -152,9 +157,11 @@ namespace CompilePalX.Compilers.BSPPack
                             string[] c = s.Split('"');
                             if (!entity.ContainsKey(c[1]))
                                 entity.Add(c[1], c[3]);
+                            entityArrayFormat.Add(Tuple.Create(c[1], c[3]));
                         }
                     }
                     entityList.Add(entity);
+                    entityListArrayForm.Add(entityArrayFormat);
                     ents = new List<byte>();
                 }
             }
@@ -260,22 +267,6 @@ namespace CompilePalX.Compilers.BSPPack
 					}
 	            }
 
-				// pack IO triggered screen_overlay materials
-				var screenOverlays = ent.Values.Where((e) => e.Contains("r_screenoverlay"));
-				if (screenOverlays.Any())
-				{
-					foreach (var screenOverlay in screenOverlays)
-					{
-						var overlay = screenOverlay.Split(',')
-							.Where((e) => e.Contains("r_screenoverlay"))
-							.Select((e) => e.Replace("r_screenoverlay ", ""))
-							.FirstOrDefault();
-
-						if (overlay != null)
-							materials.Add(overlay);
-					}
-				}
-
                 // format and add materials
                 foreach (string material in materials)
                 {
@@ -285,6 +276,26 @@ namespace CompilePalX.Compilers.BSPPack
 
                     EntTextureList.Add("materials/" + materialpath);
                 }
+            }
+
+            // get all overlay mats
+            var uniqueMats = new HashSet<string>();
+            foreach (var ent in entityListArrayForm)
+            {
+                foreach(var kv in ent)
+                {
+                    var match = Regex.Match(kv.Item2, @"r_screenoverlay ([^,]+),");
+                    if(match.Success)
+                    {
+                        uniqueMats.Add(match.Groups[1].Value);
+                    }
+                }
+            }
+
+            foreach(var mat in uniqueMats)
+            {
+                var path = string.Format("materials/{0}.vmt", mat);
+                EntTextureList.Add(path);
             }
         }
 

--- a/CompilePalX/Compilers/Utility/ParticleUtils.cs
+++ b/CompilePalX/Compilers/Utility/ParticleUtils.cs
@@ -465,9 +465,12 @@ namespace CompilePalX.Compilers.UtilityProcess
 
                 sw.WriteLine("}");
             }
-            
-            string internalDirectory = filepath.Replace(baseDirectory, "");
 
+            string internalDirectory = filepath;
+            if(filepath.ToLower().StartsWith(baseDirectory.ToLower()))
+            {
+                internalDirectory = filepath.Substring(baseDirectory.Length);
+            }
             //Store internal/external dir so it can be packed
             particleManifest = new KeyValuePair<string, string>(internalDirectory, filepath);
         }


### PR DESCRIPTION
Made parsing better by using regex so values with // in the middle don't get mangled.

This is not the best solution though, this project needs to use a real vdf parser in every part of the code that touches vdf files, but I do not have time for that.

Fixed case problems in manifest path packing. Cleaned up dupe manifest packing.