### PR TITLE
Pack TF2 upgrade files, -noswvtx pack parameter

### DIFF
--- a/CompilePalX/Compilers/BSPPack/Pack.cs
+++ b/CompilePalX/Compilers/BSPPack/Pack.cs
@@ -64,6 +64,7 @@ namespace CompilePalX.Compilers.BSPPack
             bool packvpk = GetParameterString().Contains("-vpk");
             bool includefilelist = GetParameterString().Contains("-includefilelist");
             bool addSourceDirectory = GetParameterString().Contains("-sourcedirectory");
+            bool noswvtx = GetParameterString().Contains("-noswvtx");
 
             char[] paramChars = GetParameterString().ToCharArray();
             List<string> parameters = ParseParameters(paramChars);
@@ -262,7 +263,7 @@ namespace CompilePalX.Compilers.BSPPack
 
                 CompilePalLogger.LogLine("Initializing pak file...");
                 PakFile pakfile = new PakFile(map, sourceDirectories, includeFiles, excludeFiles, excludeDirs,
-                    excludedVpkFiles, outputFile);
+                    excludedVpkFiles, outputFile, noswvtx);
 
                 if (includefilelist)
                 {

--- a/CompilePalX/Compilers/BSPPack/PakFile.cs
+++ b/CompilePalX/Compilers/BSPPack/PakFile.cs
@@ -138,17 +138,14 @@ namespace CompilePalX.Compilers.BSPPack
                     AddInternalFile(cc["filename"], FindExternalFile(cc["filename"]));
 
             // find upgrade station files
-            else
+            foreach (Dictionary<string, string> relay in bsp.entityList.Where(item => item["classname"].Length > 0))
             {
-                foreach (Dictionary<string, string> relay in bsp.entityList.Where(item => item["classname"].Length > 0))
+                foreach (string v in relay.Values)
                 {
-                    foreach (string v in relay.Values)
-                    {
-                        if (!v.ToLower().Trim().Contains("setcustomupgradesfile")) continue;
+                    if (!v.ToLower().Trim().Contains("setcustomupgradesfile")) continue;
 
-                        string[] split = v.Split((char)27);
-                        AddInternalFile(split[2], FindExternalFile(split[2]));
-                    }
+                    string[] split = v.Split((char)27);
+                    AddInternalFile(split[2], FindExternalFile(split[2]));
                 }
             }
 

--- a/CompilePalX/Compilers/BSPPack/PakFile.cs
+++ b/CompilePalX/Compilers/BSPPack/PakFile.cs
@@ -132,23 +132,6 @@ namespace CompilePalX.Compilers.BSPPack
                 }
             }
 
-            // find color correction files
-            foreach (Dictionary<string, string> cc in bsp.entityList.Where(item => item["classname"] == "color_correction"))
-                if (cc.ContainsKey("filename"))
-                    AddInternalFile(cc["filename"], FindExternalFile(cc["filename"]));
-
-            // find upgrade station files
-            foreach (Dictionary<string, string> relay in bsp.entityList.Where(item => item["classname"].Length > 0))
-            {
-                foreach (string v in relay.Values)
-                {
-                    if (!v.ToLower().Trim().Contains("setcustomupgradesfile")) continue;
-
-                    string[] split = v.Split((char)27);
-                    AddInternalFile(split[2], FindExternalFile(split[2]));
-                }
-            }
-
             foreach (KeyValuePair<string, string> vehicleScript in bsp.VehicleScriptList)
                 if (AddInternalFile(vehicleScript.Key, vehicleScript.Value))
                     vehiclescriptcount++;
@@ -167,6 +150,8 @@ namespace CompilePalX.Compilers.BSPPack
                 AddTexture(vmt);
             foreach (string vmt in bsp.EntTextureList)
                 AddTexture(vmt);
+            foreach (string misc in bsp.MiscList)
+                AddInternalFile(misc, FindExternalFile(misc));
             foreach (string sound in bsp.EntSoundList)
                 if (AddInternalFile(sound, FindExternalFile(sound)))
                     sndcount++;
@@ -303,14 +288,14 @@ namespace CompilePalX.Compilers.BSPPack
                     //don't pack .sw.vtx files if param is set
                     if (reference.EndsWith(".sw.vtx") && noswvtx) 
                         continue;
-                    else    
-                        AddInternalFile(reference, FindExternalFile(reference));
+
+                    AddInternalFile(reference, ext_path);
 
                     if (reference.EndsWith(".phy"))
                         foreach (string gib in AssetUtils.findPhyGibs(ext_path))
                             AddModel(gib);
 
-                    if (reference.EndsWith(".vtx") && (!reference.EndsWith(".sw.vtx") && noswvtx))
+                    if (reference.EndsWith(".vtx"))
                         vtxMaterialNames.AddRange(AssetUtils.FindVtxMaterials(ext_path));
                 }
 

--- a/CompilePalX/Parameters/PACK/parameters.json
+++ b/CompilePalX/Parameters/PACK/parameters.json
@@ -125,5 +125,13 @@
     "CanHaveValue": true,
     "Warning": "",
     "CanBeUsedMoreThanOnce": true
+  },
+  {
+    "Name": "No .sw.vtx",
+    "Parameter": " -noswvtx",
+    "Description": "Skip packing unused .sw.vtx files to save filesize.",
+    "Value": null,
+    "CanHaveValue": false,
+    "Warning": ""
   }
 ]


### PR DESCRIPTION
Team Fortress 2's VScript update [added support for packed upgrade files](https://www.teamfortress.com/post.php?id=166703).  This simply looks for "SetCustomUpgradesFile" in the entity I/O.

.sw.vtx files are related to software rendering, a feature that has been deprecated in every modern source engine game.  Maybe some beta branch or pre-2006 branch of the engine will need them but otherwise might as well add the option to skip packing them to reduce file size a bit.

EDIT: I should clarify that no official released valve-made source engine game requires the .sw.vtx files for any sort of legacy support reasons or something either, they are completely useless space-wasting files (although pretty minor, the average uncompressed map will probably only see single digit MB differences).  Only reason I added it as a parameter and not just omitting them entirely incase there's some odd edge-case with an ancient/beta engine branch.  That being said it would probably make more sense to invert this and make it -swvtx instead.