### PR TITLE
Clean up some VRAD command descriptions, and add `-nodrawtriggers` to VBSP 

### DIFF
--- a/CompilePalX/Parameters/VBSP/parameters.json
+++ b/CompilePalX/Parameters/VBSP/parameters.json
@@ -32,6 +32,14 @@
     "Warning": ""
   },
   {
+    "Name": "Nodraw triggers",
+    "Parameter": " -nodrawtriggers",
+    "Description": "Treat trigger faces as if they were textured with nodraw, saving a small amount of lightmap space at the expense of debugability.",
+    "Value": null,
+    "CanHaveValue": false,
+    "Warning": "Only affects triggers using %compiletrigger. Func_occluders should use toolsoccluder instead of toolstrigger, to avoid issues."
+  },
+  {
     "Name": "Allow Detail Cracks",
     "Parameter": " -allowdetailcracks",
     "Description": "Don't fixup t-junctions on func_detail.",

--- a/CompilePalX/Parameters/VRAD/parameters.json
+++ b/CompilePalX/Parameters/VRAD/parameters.json
@@ -61,12 +61,12 @@
     "Description": "Trace N times as many rays for indirect light and sky ambient.",
     "Value": null,
     "CanHaveValue": true,
-    "Warning": ""
+    "Warning": "Normal default is 1; -final default is 16"
   },
   {
     "Name": "Lights File",
     "Parameter": " -lights",
-    "Description": "Load a custom lights file in addition to lights.rad and map-specific lights file.",
+    "Description": "Load a custom lights (RAD) file in addition to lights.rad and map-specific lights file.",
     "Value": null,
     "ValueIsFile": true,
     "CanHaveValue": true,
@@ -75,7 +75,7 @@
   {
     "Name": "Smooth",
     "Parameter": " -smooth",
-    "Description": "Set the threshold for smoothing groups, in degrees.",
+    "Description": "Set the smoothing threshold for brush faces without smoothing groups, in degrees.",
     "Value": null,
     "CanHaveValue": true,
     "Warning": ""
@@ -102,7 +102,7 @@
     "Description": "Generate per-vertex prop_static lighting (uses higher/final quality processing)",
     "Value": null,
     "CanHaveValue": false,
-    "Warning": "",
+    "Warning": "always enabled when compiling with -final",
     "CompatibleGames": [
       730 // csgo
     ] 
@@ -167,10 +167,10 @@
   {
     "Name": "Texture Shadows",
     "Parameter": " -TextureShadows",
-    "Description": "Generates lightmap shadows from $translucent surfaces of models. (Not brushes)",
+    "Description": "Generates lightmap shadows from $alphatest and $translucent surfaces of models. (Not brushes)",
     "Value": null,
     "CanHaveValue": false,
-    "Warning": ""
+    "Warning": "Models must be compiled with $casttextureshadows or be listed with forcetextureshadow in the lights file"
   },
   {
     "Name": "AO Scale",


### PR DESCRIPTION
Synopsis:
* `$alphatest` works for texture shadows, not just `$translucent` (thank goodness)
* `-smooth` is for brush faces that *don't* have a smoothing group (that's why there are flat shading groups)
* `-extrasky 16` is implied by `-final` (so you probably don't need it)
* lights files are sometimes called RAD files, because of the file extension (I recently made a VDC page for them)
* `-staticproplightingfinal` is now implied by `-final`
* `-nodrawtriggers` can be used to shrink BSP file size a miniscule amount (it's probably useful to someone making humongous gmod maps)