### PR TITLE
fix sprite packing. skip invalid vmt files

### DIFF
--- a/CompilePalX/Compilers/BSPPack/AssetUtils.cs
+++ b/CompilePalX/Compilers/BSPPack/AssetUtils.cs
@@ -378,7 +378,17 @@ namespace CompilePalX.Compilers.BSPPack
             var vtfList = new List<string>();
             using (var w = File.OpenRead(fullpath))
             {
-                KVObject kv = KVSerializer.Deserialize(w);
+                KVObject kv;
+                try
+                {
+                    kv = KVSerializer.Deserialize(w);
+                }
+                catch(Exception e)
+                {
+                    CompilePalLogger.LogCompileError($"Error parsing file {fullpath}", new Error(e.Message, ErrorSeverity.Error));
+                    return vtfList;
+                }
+
                 foreach (var property in kv)
                 {
                     if (!Keys.vmtTextureKeyWords.Contains(property.Name, StringComparer.OrdinalIgnoreCase))

--- a/CompilePalX/Compilers/BSPPack/BSP.cs
+++ b/CompilePalX/Compilers/BSPPack/BSP.cs
@@ -249,7 +249,16 @@ namespace CompilePalX.Compilers.BSPPack
 
                 // special condition for sprites
                 if (ent["classname"].Contains("sprite") && ent.ContainsKey("model"))
-                    materials.Add(ent["model"]);
+                {
+                    var model = ent["model"];
+                    // strip leading materials folder
+                    if(model.StartsWith("materials/", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        model = model.Substring(10);
+                    }
+                    materials.Add(model);
+                }
+                    
 
                 // special condition for item_teamflag
                 if (ent["classname"].Contains("item_teamflag"))


### PR DESCRIPTION
Remove optional "materials/" from sprite material path.

Skip files that fail to parse in FindVmtTextures instead of erroring out.