### PR TITLE
RunScriptCode function parsing, pack more files 

### DIFF
--- a/CompilePalX/Compilers/BSPPack/AssetUtils.cs
+++ b/CompilePalX/Compilers/BSPPack/AssetUtils.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using CompilePalX;
 using CompilePalX.Compiling;
-using Segment.Model;
 using ValveKeyValue;
 
 namespace CompilePalX.Compilers.BSPPack

--- a/CompilePalX/Compilers/BSPPack/BSP.cs
+++ b/CompilePalX/Compilers/BSPPack/BSP.cs
@@ -451,7 +451,10 @@ namespace CompilePalX.Compilers.BSPPack
             // builds the list of models referenced in entities
 
             EntModelList = [];
-	        foreach (Dictionary<string, string> ent in entityList)
+
+            //SetModelSimple is a vscript input
+            string[] modelcommands = ["SetModel", "SetCustomModel", "SetCustomModelWithClassAnimations"];
+            foreach (Dictionary<string, string> ent in entityList)
 	        {
 				foreach (KeyValuePair<string, string> prop in ent)
 				{
@@ -489,7 +492,7 @@ namespace CompilePalX.Compilers.BSPPack
 
                     var (target, command, parameter) = io;
 
-                    if (command == "SetModel")
+                    if (modelcommands.Contains(command))
                         EntModelList.Add(parameter);
                 }
             }
@@ -517,7 +520,9 @@ namespace CompilePalX.Compilers.BSPPack
                         continue;
 
                     var (target, command, parameter) = io;
-                    if (command == "PlayVO")
+
+                    // StartsWith to check PlayVO, PlayVORed, PlayVOBlue
+                    if (command.StartsWith("PlayVO"))
                     {
                         //Parameter value following PlayVO is always either a sound path or an empty string
                         if (!string.IsNullOrWhiteSpace(parameter)) 
@@ -558,6 +563,7 @@ namespace CompilePalX.Compilers.BSPPack
                     if (io == null) continue;
 
                     var (target, command, parameter) = io;
+
                     if (command.ToLower() != "setcustomupgradesfile") continue;
 
                     MiscList.Add(parameter);
@@ -580,7 +586,7 @@ namespace CompilePalX.Compilers.BSPPack
         /// </summary>
         /// <param name="property">Entity property</param>
         /// <returns>Tuple containing (target, command, parameter)</returns>
-        private Tuple<string, string, string>? ParseIO(string property)
+        public Tuple<string, string, string>? ParseIO(string property, bool vscriptIO = false)
         {
             // io is split by unicode escape char
             if (!property.Contains("\u001b"))
@@ -617,8 +623,15 @@ namespace CompilePalX.Compilers.BSPPack
                     parameter = splitIo[2];
                 }
             }
+            // Parse VScript RunScriptCode parameters for assets and basic syntax errors
+            else if (vscriptIO && targetInput == "RunScriptCode" && parameter.Contains('`'))
+            {
+                char[] trim = { '(', ',' };
+                string strippedparam = parameter.Trim(trim);
+                string[] splitparam = parameter.Split('`');
+            }
 
-            return new Tuple<string, string, string>(io[0], targetInput, parameter);
+                return new Tuple<string, string, string>(io[0], targetInput, parameter);
         }
     }
 }

--- a/CompilePalX/Compilers/BSPPack/BSP.cs
+++ b/CompilePalX/Compilers/BSPPack/BSP.cs
@@ -529,7 +529,7 @@ namespace CompilePalX.Compilers.BSPPack
                             if (scriptArgs[i].Contains(".Set"))
                                 funcOnly = $"S{scriptArgs[i].Split(".S")[1]}";
 
-                            if ((modelcommands.Contains(funcOnly) || funcOnly == "SetModelSimple") && arg != default)
+                            if (funcOnly != "" && (modelcommands.Contains(funcOnly) || funcOnly == "SetModelSimple") && arg != default)
                                 EntModelList.Add(arg);
                         }
                     }
@@ -776,7 +776,7 @@ namespace CompilePalX.Compilers.BSPPack
                 scriptArgs = [..argsList];
 
                 if (trimScriptBackticks)
-                    scriptArgs.Select(x => x = x.Trim('`'));
+                    scriptArgs = [.. scriptArgs.Select(x => x.Trim('`'))];
             }
 
              return new Tuple<string, string, string, string[]>(io[0], targetInput, parameter, scriptArgs);


### PR DESCRIPTION
- Rudimentary VScript I/O parsing.  Needs more testing but should scan for files in:
    - `IncludeScript/DoIncludeScript`
    - `SetSkyboxTexture`
    - `SetScriptOverlayMaterial`
    - `EmitSound/EmitSoundEx/EmitAmbientSoundOn`
    - All `SetModel` related functions
    - `DispatchParticleEffect`
- Error logging for invalid strings in VScript I/O
- `VScriptTableToDict` util function
- Made most I/O asset checks case-insensitive
- Additional I/O and ent KV file checks:
    - `RunScriptFile` (all)
    - `particle_name` (trigger_particle)
    - `explode_particle` (tf_generic_bomb)
    - `PlayVORed/PlayVOBlue` (tf_gamerules)
    - `SetOverlayMaterial` (player)
    - `SetCustomModel/SetCustomModelWithClassAnimations` (player)
- Pack mvm-specific `mvm_level_sound_tweaks.txt` file for MvM maps (they use this file for soundscripts instead.)
- Fixed a typo