### PR TITLE
Fixed improper parsing of particles with version 5.2

### DIFF
--- a/CompilePalX/Compilers/BSPPack/BSP.cs
+++ b/CompilePalX/Compilers/BSPPack/BSP.cs
@@ -646,7 +646,7 @@ namespace CompilePalX.Compilers.BSPPack
             {
                 foreach (var prop in ent)
                 {
-                    if (particleKeys.Contains(prop.Item2.ToLower()))
+                    if (particleKeys.Contains(prop.Item1.ToLower()))
                         ParticleList.Add(prop.Item2.ToLower());
 
                     var io = ParseIO(prop.Item2); 

--- a/CompilePalX/Compilers/Utility/ParticleUtils.cs
+++ b/CompilePalX/Compilers/Utility/ParticleUtils.cs
@@ -279,7 +279,12 @@ namespace CompilePalX.Compilers.UtilityProcess
                 int numElementAttribs = reader.ReadInt32();
                 for (int n = 0; n < numElementAttribs; n++)
                 {
-                    int typeID = reader.ReadUInt16();
+                    int typeID;
+                    if (pcf.BinaryVersion == 5)
+                        typeID = (int)reader.ReadUInt32();
+                    else
+                        typeID = reader.ReadUInt16();
+
                     int attributeType = reader.ReadByte();
                     string attributeTypeName = pcf.StringDict[typeID];
 

--- a/CompilePalX/Compilers/Utility/ParticleUtils.cs
+++ b/CompilePalX/Compilers/Utility/ParticleUtils.cs
@@ -36,7 +36,7 @@ namespace CompilePalX.Compilers.UtilityProcess
             {
                 if (s.EndsWith(".mdl"))
                 {
-                    modelList.Add(s);
+                    modelList.Add(Path.Combine("models", s));
                 }
             }
             ModelNames = modelList;
@@ -51,14 +51,9 @@ namespace CompilePalX.Compilers.UtilityProcess
 
             foreach (string s in StringDict)
             {
-
                 if (s.EndsWith(".vmt") || s.EndsWith(".vtf"))
                 {
-                    // Alien Swarm does not prepend materials/ to particles, add it just in case
-                    if (BinaryVersion == 5 && PcfVersion == 2)
-                        materialNames.Add("materials\\" + s);
-
-                    materialNames.Add(s);
+                    materialNames.Add(Path.Combine("materials", s));
                 }
             }
             return materialNames;

--- a/CompilePalX/Compilers/Utility/ParticleUtils.cs
+++ b/CompilePalX/Compilers/Utility/ParticleUtils.cs
@@ -136,8 +136,18 @@ namespace CompilePalX.Compilers.UtilityProcess
                 }
                 else if (pcf.BinaryVersion == 5)
                 {
-                    int elementNameIndex = (int)reader.ReadUInt32();
+                    //Structure is either:
+                    //ushort nameIndex
+                    //ushort descIndex //All checked pcfs 5.2 had this set as 00 00 for all cases
+                    //
+                    //or
+                    //uint nameIndex
+                    //
+                    //If it's the second option in order to use the last 2 bytes there would need to be over 65535 strings in the stringDict.
+                    //Since it's unknown which structure is correct it's safer to read it as ushort and skip next 2 bytes
+                    int elementNameIndex = reader.ReadUInt16();
                     elementName = pcf.StringDict[elementNameIndex];
+                    fs.Seek(2, SeekOrigin.Current);
                 }
 
                 //Skip data signature
@@ -235,8 +245,18 @@ namespace CompilePalX.Compilers.UtilityProcess
                 }
                 else if (pcf.BinaryVersion == 5)
                 {
-                    int elementNameIndex = (int)reader.ReadUInt32();
+                    //Structure is either:
+                    //ushort nameIndex
+                    //ushort descIndex //All checked pcfs 5.2 had this set as 00 00 for all cases
+                    //
+                    //or
+                    //uint nameIndex
+                    //
+                    //If it's the second option in order to use the last 2 bytes there would need to be over 65535 strings in the stringDict.
+                    //Since it's unknown which structure is correct it's safer to read it as ushort and skip next 2 bytes
+                    int elementNameIndex = reader.ReadUInt16();
                     elementName = pcf.StringDict[elementNameIndex];
+                    fs.Seek(2, SeekOrigin.Current);
                 }
 
                 //Skip data signature

--- a/CompilePalX/Compilers/Utility/ParticleUtils.cs
+++ b/CompilePalX/Compilers/Utility/ParticleUtils.cs
@@ -120,7 +120,12 @@ namespace CompilePalX.Compilers.UtilityProcess
             int numElements = reader.ReadInt32();
             for (int i = 0; i < numElements; i++)
             {
-                int typeNameIndex = reader.ReadUInt16();
+                int typeNameIndex;
+                if (pcf.BinaryVersion == 5)
+                    typeNameIndex = (int)reader.ReadUInt32();
+                else
+                    typeNameIndex = reader.ReadUInt16();
+
                 string typeName = pcf.StringDict[typeNameIndex];
 
                 string elementName = "";
@@ -128,39 +133,30 @@ namespace CompilePalX.Compilers.UtilityProcess
                 if (pcf.BinaryVersion != 4 && pcf.BinaryVersion != 5)
                 {
                     elementName = ReadNullTerminatedString(fs, reader);
-                    //Skip data signature
-                    fs.Seek(16, SeekOrigin.Current);
                 }
                 else if (pcf.BinaryVersion == 4)
                 {
                     int elementNameIndex = reader.ReadUInt16();
                     elementName = pcf.StringDict[elementNameIndex];
-                    fs.Seek(16, SeekOrigin.Current);
                 }
                 else if (pcf.BinaryVersion == 5)
                 {
-                    int elementNameIndex = reader.ReadUInt16();
+                    int elementNameIndex = (int)reader.ReadUInt32();
                     elementName = pcf.StringDict[elementNameIndex];
-                    fs.Seek(20, SeekOrigin.Current);
                 }
-                
+
+                //Skip data signature
+                fs.Seek(16, SeekOrigin.Current);
+
                 //Get particle names
                 if (typeName == "DmeParticleSystemDefinition")
                     pcf.ParticleNames.Add(elementName);
 
             }
 
-            bool containsParticle = false;
-            foreach (string particleName in pcf.ParticleNames)
-            {
-                foreach (string targetParticle in targetParticles)
-                {
-                    if (particleName == targetParticle)
-                    {
-                        containsParticle = true;
-                    }
-                }
-            }
+            bool containsParticle = pcf.ParticleNames
+                                    .Intersect(targetParticles, StringComparer.OrdinalIgnoreCase)
+                                    .Any();
 
             //If target particle is not in pcf dont read it
             reader.Close();
@@ -223,7 +219,12 @@ namespace CompilePalX.Compilers.UtilityProcess
             int numElements = reader.ReadInt32();
             for (int i = 0; i < numElements; i++)
             {
-                int typeNameIndex = reader.ReadUInt16();
+                int typeNameIndex;
+                if (pcf.BinaryVersion == 5)
+                    typeNameIndex = (int)reader.ReadUInt32();
+                else
+                    typeNameIndex = reader.ReadUInt16();
+
                 string typeName = pcf.StringDict[typeNameIndex];
 
                 string elementName = "";
@@ -231,22 +232,21 @@ namespace CompilePalX.Compilers.UtilityProcess
                 if (pcf.BinaryVersion != 4 && pcf.BinaryVersion != 5)
                 {
                     elementName = ReadNullTerminatedString(fs, reader);
-                    //Skip data signature
-                    fs.Seek(16, SeekOrigin.Current);
                 }
                 else if (pcf.BinaryVersion == 4)
                 {
                     int elementNameIndex = reader.ReadUInt16();
                     elementName = pcf.StringDict[elementNameIndex];
-                    fs.Seek(16, SeekOrigin.Current);
                 }
                 else if (pcf.BinaryVersion == 5)
                 {
-                    int elementNameIndex = reader.ReadUInt16();
+                    int elementNameIndex = (int)reader.ReadUInt32();
                     elementName = pcf.StringDict[elementNameIndex];
-                    fs.Seek(20, SeekOrigin.Current);
                 }
-                
+
+                //Skip data signature
+                fs.Seek(16, SeekOrigin.Current);
+
                 //Get particle names
                 if (typeName == "DmeParticleSystemDefinition")
                     pcf.ParticleNames.Add(elementName);


### PR DESCRIPTION
## Changes
- BSP.cs compared the wrong Item to particleKeys ( value from prop instead of the key )
- Fixed improper parsing of pcf 5.2

Followed [Valve Developer Wiki](https://developer.valvesoftware.com/wiki/PCF) to make parsing changes

## Important Note
These changes were made and tested in my packing tool ( [bspPack](https://github.com/Natanxp2/bspPack) ) stripped out of CompilePal packing functionality. 
I do not currently have access to windows to properly test them in CompilePal.

EDIT: Added a commit to fully close #143 
