### PR TITLE
Fixed mvm level_sounds pack renaming not working correctly

### DIFF
--- a/CompilePalX/Compilers/BSPPack/AssetUtils.cs
+++ b/CompilePalX/Compilers/BSPPack/AssetUtils.cs
@@ -674,13 +674,15 @@ namespace CompilePalX.Compilers.BSPPack
 
             // Soundscript file.
             // TF2 MvM maps use a special script file instead.
-            internalPath = !mapName.StartsWith("mvm_") ? "maps/" + mapName.Replace(".bsp", "") + "_level_sounds.txt" : "scripts/mvm_level_sound_tweaks.txt";
+            internalPath = "maps/" + mapName.Replace(".bsp", "") + "_level_sounds.txt";
             foreach (string source in sourceDirectories)
             {
                 string externalPath = source + "/" + internalPath;
 
                 if (File.Exists(externalPath))
                 {
+                    if (mapName.StartsWith("mvm_"))
+                        internalPath = "scripts/mvm_level_sound_tweaks.txt";
                     bsp.soundscript = new KeyValuePair<string, string>(internalPath, externalPath);
                     break;
                 }
@@ -942,8 +944,11 @@ namespace CompilePalX.Compilers.BSPPack
                         }
                         // soundscript
                         if (f.Name.StartsWith(name + "_level_sounds") || (mapName.StartsWith("mvm_") && f.Name == "mvm_level_sound_tweaks.txt"))
+                        {
+                            string internalName = mapName.StartsWith("mvm_") ? "scripts/mvm_level_sound_tweaks.txt" : internalDir + f.Name;
                             bsp.soundscript =
-                                new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name);
+                                new KeyValuePair<string, string>(internalName, externalDir + f.Name);
+                        }
                         // presumably language files
                         else
                             langfiles.Add(new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name));


### PR DESCRIPTION
Recently a feature was added that renames `maps/%bspname%_level_sounds.txt` to `scripts/mvm_level_sound_tweaks.txt` during packing for MvM maps.

However, it doesn't work in practice because of two reasons this PR fixes:

- At Line 682 `File.Exists` performs a check on `scripts/mvm_level_sound_tweaks.txt` rather than the actual file it's supposed to read - `maps/%bspname%_level_sounds.txt`.

- At Line 945 the entire block of code looks odd; seems like it's overriding the soundscript-related work done at Line 682. I've kept the logic and made it rename the soundscript file for MvM map in case that block of code was important, but most likely the the block under the if statement should just be empty.