### PR TITLE
Add -renameparticlemanifest and Change MvM Soundscript Check

### DIFF
--- a/CompilePalX/Compilers/BSPPack/AssetUtils.cs
+++ b/CompilePalX/Compilers/BSPPack/AssetUtils.cs
@@ -643,7 +643,7 @@ namespace CompilePalX.Compilers.BSPPack
             return dict;
         }
 
-        public static void FindBspUtilityFiles(BSP bsp, List<string> sourceDirectories, bool renameparticlemanifest, bool renamenav, bool genparticlemanifest)
+        public static void FindBspUtilityFiles(BSP bsp, List<string> sourceDirectories, bool renamenav, bool renameparticlemanifest, bool genparticlemanifest)
         {
             // Utility files are other files that are not assets and are sometimes not referenced in the bsp
             // those are manifests, soundscapes, nav, radar and detail files

--- a/CompilePalX/Compilers/BSPPack/AssetUtils.cs
+++ b/CompilePalX/Compilers/BSPPack/AssetUtils.cs
@@ -643,7 +643,7 @@ namespace CompilePalX.Compilers.BSPPack
             return dict;
         }
 
-        public static void FindBspUtilityFiles(BSP bsp, List<string> sourceDirectories, bool renamenav, bool genparticlemanifest)
+        public static void FindBspUtilityFiles(BSP bsp, List<string> sourceDirectories, bool renameparticlemanifest, bool renamenav, bool genparticlemanifest)
         {
             // Utility files are other files that are not assets and are sometimes not referenced in the bsp
             // those are manifests, soundscapes, nav, radar and detail files
@@ -936,22 +936,30 @@ namespace CompilePalX.Compilers.BSPPack
                     foreach (FileInfo f in dir.GetFiles(searchPattern))
                     {
                         // particle files if particle manifest is not being generated
-                        if (f.Name.StartsWith(name + "_particles") || f.Name.StartsWith(name + "_manifest"))
+                        if (f.Name.StartsWith(name + "_particles"))
                         {
-                            if(!genparticlemanifest)
+                            if (!genparticlemanifest)
+                            {
+                                if (renameparticlemanifest)
+                                    internalPath = "particles.txt";
+
                                 bsp.particleManifest = new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name);
+                            }
+
                             continue;
                         }
+
                         // soundscript
                         if (f.Name.StartsWith(name + "_level_sounds") || (mapName.StartsWith("mvm_") && f.Name == "mvm_level_sound_tweaks.txt"))
                         {
-                            string internalName = mapName.StartsWith("mvm_") ? "scripts/mvm_level_sound_tweaks.txt" : internalDir + f.Name;
-                            bsp.soundscript =
-                                new KeyValuePair<string, string>(internalName, externalDir + f.Name);
+                            string internalName = mapName.Contains("mvm") ? "scripts/mvm_level_sound_tweaks.txt" : internalDir + f.Name;
+                            bsp.soundscript = new KeyValuePair<string, string>(internalName, externalDir + f.Name);
+
+                            continue;
                         }
+
                         // presumably language files
-                        else
-                            langfiles.Add(new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name));
+                        langfiles.Add(new KeyValuePair<string, string>(internalDir + f.Name, externalDir + f.Name));
                     }
             }
             bsp.languages = langfiles;

--- a/CompilePalX/Compilers/BSPPack/Pack.cs
+++ b/CompilePalX/Compilers/BSPPack/Pack.cs
@@ -58,6 +58,7 @@ namespace CompilePalX.Compilers.BSPPack
             verbose = GetParameterString().Contains("-verbose");
             bool dryrun = GetParameterString().Contains("-dryrun");
             bool renamenav = GetParameterString().Contains("-renamenav");
+            bool renameparticlemanifest = GetParameterString().Contains("-renameparticlemanifest");
             bool include = Regex.IsMatch(GetParameterString(), @"-include\b"); // ensures it doesnt match -includedir
             bool includeDir = GetParameterString().Contains("-includedir");
             bool exclude = Regex.IsMatch(GetParameterString(), @"-exclude\b"); // ensures it doesnt match -excludedir
@@ -255,7 +256,7 @@ namespace CompilePalX.Compilers.BSPPack
                     return;
                 }
 
-                AssetUtils.FindBspUtilityFiles(map, sourceDirectories, renamenav, genParticleManifest);
+                AssetUtils.FindBspUtilityFiles(map, sourceDirectories, renamenav, renameparticlemanifest, genParticleManifest);
 
                 // give files unique names based on map so they dont get overwritten
                 if (dryrun)

--- a/CompilePalX/Parameters/PACK/parameters.json
+++ b/CompilePalX/Parameters/PACK/parameters.json
@@ -23,8 +23,23 @@
     "CanHaveValue": false,
     "Warning": "",
     "CompatibleGames": [
+      240, //css
+      300, //dod
       440 //tf2
-    ] 
+    ]
+  },
+  {
+    "Name": "Rename Particle Manifest",
+    "Parameter": " -renameparticlemanifest",
+    "Description": "Renames the particle manifest file to particles.txt",
+    "Value": null,
+    "CanHaveValue": false,
+    "Warning": "",
+    "CompatibleGames": [
+      240, //css
+      300, //dod
+      440 //tf2
+    ]
   },
   {
     "Name": "Include",


### PR DESCRIPTION
Adds the -renameparticlemanifest PACK parameter to all Source 2013 games.
Renames the found "maps/mapname_particles.txt" to "particles.txt", allowing it to be read even if the map name doesn't match. Similar to "embed.nav" rename system used by NAV files.
Currently doesn't support the particle manifest files generated by CompilePal as I am not sure how to handle it with the codebase.
Removed the "mapname_manifest" filename detection as that doesn't seem to be a valid format.
https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/game/shared/particle_parse.cpp#L195

Changed the MvM map name check to check if map name contains "mvm" instead of checking if map name starts with "mvm_" as that seems to be how game handles it. Some maps abuse this to add "mvm" to end of their map name to load MvM soundscripts instead.
https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/game/shared/SoundEmitterSystem.cpp#L277
