### PR TITLE
Update sprite condition to include env_glow

### DIFF
--- a/CompilePalX/Compilers/BSPPack/BSP.cs
+++ b/CompilePalX/Compilers/BSPPack/BSP.cs
@@ -257,7 +257,7 @@ namespace CompilePalX.Compilers.BSPPack
                 }
 
                 // special condition for sprites
-                if (ent["classname"].Contains("sprite") && ent.ContainsKey("model"))
+                if ((ent["classname"].Contains("sprite") || ent["classname"].Contains("glow")) && ent.ContainsKey("model"))
                 {
                     var model = ent["model"];
                     // strip leading materials folder


### PR DESCRIPTION
Making Pack process supports env_glow entity.
https://developer.valvesoftware.com/wiki/Env_sprite#:~:text=also%20tied%20to-,env_glow,-.%20This%20might%20be